### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -8,6 +8,10 @@ on:
 jobs:
   stale:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
     steps:
       - uses: actions/stale@v8
         with:


### PR DESCRIPTION
Potential fix for [https://github.com/grzegorz914/homebridge-tasmota-control/security/code-scanning/1](https://github.com/grzegorz914/homebridge-tasmota-control/security/code-scanning/1)

To fix the problem, explicitly declare `permissions` for the `GITHUB_TOKEN` so the job does not inherit overly broad repository defaults. Since this stale workflow needs to mark issues/PRs as stale, add labels, and close them, it requires write access to `issues` and `pull-requests`. It does not need broader repository write access, so we can keep `contents` at `read`.

The single best change, without altering existing functionality, is to add a `permissions` block under the `stale` job (line 9) in `.github/workflows/stale.yml`. This block should specify:
- `contents: read` (minimal standard)
- `issues: write`
- `pull-requests: write`

No imports or additional methods are needed because this is a YAML workflow definition. We only add the new `permissions` mapping at the correct indentation level so it applies to the `stale` job.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
